### PR TITLE
chore: improve development environment and build configuration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,64 @@
+# vim: set foldmethod=marker foldmarker={{{,}}}:
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+source "$TW_BINX/lib/sane_fn.sh"
+PROJ_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export PROJ_DIR
+#Green "-M- exporting PROJ_DIR: $PROJ_DIR"
+
+############### Python ###############
+# Emulate the pipenvs's activate, because we can't source things in direnv
+#layout_pipenv
+#layout_poetry
+#layout_rye
+layout_uv
+#dotenv
+export PYTHONPATH=$PROJ_DIR
+export PIPENV_VENV_IN_PROJECT=1  # creates .venv
+#export POETRY_VIRTUALENVS_IN_PROJECT=1  # creates .venv
+
+if which tmux > /dev/null 2>&1; then
+    tmux rename-window "$(basename "$PROJ_DIR")"
+fi
+
+############### Exports ###############
+export RUN_ENV=local
+export senv="source $PROJ_DIR/scripts/env.sh"
+#export TW_FZF_ROOT="$HOME/dev"
+#export SHOW_TF_PROMPT=0
+
+############### Java ###############
+#export MAVEN_PROFILE=bmw
+#export JAVA_HOME="$HOME/.asdf/installs/java/openjdk-20"
+#PATH_add $JAVA_HOME/bin
+
+############### BMW ###############
+#export GH_HOST=atc-github.azure.cloud.bmw
+#dotenv ~/dev/s/private/sec-sops/bmw.env
+
+export RPLC_CONFIG="$VIMWIKI_PATH/dev/vimania-uri-rs.md"
+export RPLC_MIRROR_DIR="$HOME/dev/s/private/py-twlib/rplc/sysid/vimania-uri-rs"
+swapin() {
+    rplc -v swapin
+    direnv allow
+}
+export_function swapin
+swapout() {
+    rplc -v swapout
+    direnv allow
+}
+export_function swapout
+
+### unset for PyPi
+#unset TWINE_USERNAME
+#unset TWINE_PASSWORD
+
+# LOS {{{ #
+#ln -fs $HOME/dev/lospy/static-code-analyser-configs/teams/cobra/.editorconfig .
+#cp -fv $HOME/dev/lospy/static-code-analyser-configs/teams/cobra/.editorconfig .
+#export GITHUB_ACTOR=q187392
+#export GITHUB_TOKEN=<token_here>
+#export _JAVA_OPTIONS="-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=3128 -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=3128 -Dhttps.nonProxyHosts=localhost|*.bmwgroup.net|*.muc -Dhttp.nonProxyHosts=localhost|*.bmwgroup.net|*.muc"
+# }}} LOS #
+PATH_add $PROJ_DIR/scripts
+export RPLC_SWAPPED=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.direnv/
+tags
 doc/~*
 .idea/runConfigurations/_template__of_py_test*
 pythonx/*

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,6 @@ tests_src = $(app_root)/tests
 # Makefile directory
 CODE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-.PHONY: all
-all: clean build upload tag  ## Build and upload
-	@echo "--------------------------------------------------------------------------------"
-	@echo "-M- building and distributing"
-	@echo "--------------------------------------------------------------------------------"
-
 ################################################################################
 # Developing \
 DEVELOPING:  ## ###############################################################
@@ -148,15 +142,6 @@ create-release: check-github-token  ## create a release on GitHub via the gh cli
 		gh release create "v$(VERSION)" --generate-notes --latest; \
 	fi
 
-.PHONY: create-release
-create-release:  ## create a release on GitHub via the gh cli
-	@if command -v gh version &>/dev/null; then \
-		echo "Creating GitHub release for v$(VERSION)"; \
-		gh release create "v$(VERSION)" --generate-notes; \
-	else \
-		echo "You do not have the github-cli installed. Please create release from the repo manually."; \
-		exit 1; \
-	fi
 
 .PHONY: check-github-token
 check-github-token:  ## Check if GITHUB_TOKEN is set

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
-use pyo3_build_config;
+use pyo3_build_config::add_extension_module_link_args;
 
 fn main() {
-    pyo3_build_config::add_extension_module_link_args();
+    add_extension_module_link_args();
 }

--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "vimania-uri-rs"
-version = "1.1.7"
+version = "2.0.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Add direnv configuration for standardized development environment setup
- Clean up build configuration and Makefile inconsistencies  
- Update gitignore for better development workflow

## Changes

- **Add `.envrc`**: Provides direnv support with uv layout, Python path configuration, and project-specific environment variables
- **Update `.gitignore`**: Exclude `.direnv/` directory and `tags` files from version control
- **Fix Makefile**: Remove duplicate `create-release` target that was causing conflicts
- **Fix build.rs**: Update deprecated `pyo3_build_config` import to use specific function import
- **Update uv.lock**: Reflect version bump to 2.0.2
